### PR TITLE
use babel when needed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import path from 'path';
+import fs from 'fs';
 import commander from 'commander';
-import requireCwd from 'req-cwd';
+import resolveCwd from 'resolve-cwd';
 
 commander
   .usage('[options] <tasks runner> [arguments]')
@@ -10,23 +10,23 @@ commander
   .option('-p, --preset, <preset>', 'tasks preset')
   .parse(process.argv);
 
-let tasks = null;
+let modulePath = null;
 
 if (commander.preset) {
-  try {
-    tasks = requireCwd(commander.preset);
-  } catch (e) {
+  modulePath = resolveCwd(commander.preset);
+  if (!modulePath || !fs.existsSync(modulePath)) { // eslint-disable-line
     console.error(`Unable to find "${commander.preset}" preset, please check it again`);
     process.exit(1);
   }
 } else {
-  try {
-    tasks = require(path.resolve(commander.file));
-  } catch (e) {
+  modulePath = resolveCwd(`./${commander.file}`);
+  if (!modulePath || !fs.existsSync(modulePath)) { // eslint-disable-line
     console.error(`Unable to find "${commander.file}" file, please check it again`);
     process.exit(1);
   }
 }
+
+const tasks = require(modulePath);
 
 const getAvailableTasksRunnersMessage = () => {
   return `Available tasks runners: "${Object.keys(tasks).join('", "')}"`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,49 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-sync */
+
 import fs from 'fs';
 import commander from 'commander';
 import resolveCwd from 'resolve-cwd';
 
 commander
   .usage('[options] <tasks runner> [arguments]')
-  .option('-f, --file, <file>', 'tasks file path, tasks.js by default', 'tasks.js')
+  .option('-f, --file, <file>', 'tasks file path, tasks.js by default')
   .option('-p, --preset, <preset>', 'tasks preset')
   .parse(process.argv);
 
 let modulePath = null;
+let useBabel = false;
 
 if (commander.preset) {
   modulePath = resolveCwd(commander.preset);
-  if (!modulePath || !fs.existsSync(modulePath)) { // eslint-disable-line
+  if (!modulePath || !fs.existsSync(modulePath)) {
     console.error(`Unable to find "${commander.preset}" preset, please check it again`);
     process.exit(1);
   }
-} else {
+} else if (commander.file) {
+  if (commander.file.match(/(\.babel\.js|\.es6?)$/)) {
+    useBabel = true;
+  }
   modulePath = resolveCwd(`./${commander.file}`);
-  if (!modulePath || !fs.existsSync(modulePath)) { // eslint-disable-line
+  if (!modulePath || !fs.existsSync(modulePath)) {
     console.error(`Unable to find "${commander.file}" file, please check it again`);
     process.exit(1);
   }
+} else {
+  modulePath = resolveCwd('./tasks.js');
+  if (!modulePath) {
+    useBabel = true;
+    modulePath = resolveCwd('./tasks.babel.js');
+  }
+  if (!modulePath || !fs.existsSync(modulePath)) {
+    console.error('Unable to find "tasks.js" file, please check it again');
+    process.exit(1);
+  }
+}
+
+if (useBabel) {
+  require('babel-register'); // eslint-disable-line
 }
 
 const tasks = require(modulePath);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "build/index.js",
   "dependencies": {
     "commander": "^2.9.0",
-    "req-cwd": "^1.0.1"
+    "resolve-cwd": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "commander": "^2.9.0",
     "resolve-cwd": "^1.0.0"
   },
+  "peerDependencies": {
+    "babel-register": "*"
+  },
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-preset-start": "^0.1.0",


### PR DESCRIPTION
if the filename matches .babel.js register babel require hook

So if you specify `tasks.babel.js` it will auto-compile with babel. 

`tasks.babel.js` is now also an additional default 

(this is similar to how webpack does it - with `webpack.config.babel.js`)

fixes https://github.com/start-runner/start/issues/24

(includes #9, let me know if you want them rebased separately onto master) 
